### PR TITLE
cache public keys in worker secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .wrangler/
 .dev.vars
+.secret.json
+put-secret.sh

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Depends on [@tsndr/cloudflare-worker-jwt](https://github.com/tsndr/cloudflare-wo
 
 [The code](https://github.com/jldec/access-jwt/blob/main/src/index.js#L10-L43) fetches public keys from `https://${env.ACCESS_TEAM_NAME}.cloudflareaccess.com/cdn-cgi/access/certs`. Your team name can be found in the Custom Pages settings of the Cloudflare [Zero Trust dashboard](https://one.dash.cloudflare.com).
 
+To avoid making a fetch request on the certs endpoint for every JWT validation, public keys are cached in a worker secret CLOUDFLARE_ACCESS_PUBLIC_KEYS. A query parameter of `f=1` will force this value to be refreshed. (TODO force a refresh with a weekly cron worker)
+
 By decoding the JWT from the `CF_Authorization` cookie instead of relying on the `cf-access-jwt-assertion` header, you can continue identifying authenticated users even for un-authed routes on the same origin, once they have logged in. This works because the cookie is scoped to the hostname unless you explicitly configure Access to scope the cookie to the application path.
 
 Originally motivated by [this thread](https://x.com/adam_janis/status/1823330661140181204) by [Adam Janiš](https://github.com/eidam).  
@@ -17,8 +19,10 @@ https://access-jwt.jldec.me/
 
 
 ### To deploy on your own Cloudflare Access protected endpoint
-- Set ACCESS_TEAM_NAME to your own Cloudflare Access team name in wrangler.toml.
-- Run `pnpm install` and `pnpm run deploy`.
+- Run `pnpm install` and `pnpm ship`
+  (using 'ship' instead of 'deploy' allows 'pnpm ship' without 'run')
+- Set the necessary secrets using `pnpm wrangler secret put <SECRET_NAME>`
+  See wrangler.toml for details.
 - Configure the deployed worker to trigger on your endpoint.
 - Open the endpoint and authenticate with your browser.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler deploy",
+		"ship": "wrangler deploy",
 		"dev": "wrangler dev",
 		"start": "wrangler dev"
 	},
@@ -11,7 +11,7 @@
 		"@tsndr/cloudflare-worker-jwt": "^3.1.3"
 	},
 	"devDependencies": {
-		"wrangler": "^3.90.0"
+		"wrangler": "^3.91.0"
 	},
 	"prettier": {
 		"useTabs": true,

--- a/src/index.js
+++ b/src/index.js
@@ -96,14 +96,15 @@ export default {
 				throw new Error(
 					`${response.statusText} Error fetching Cloudflare Access public keys from ${keysUrl}`
 				)
-			const publicKeys = await response.json()
-			if (typeof publicKeys !== 'object' || !publicKeys.keys) {
+			const obj = await response.json()
+			if (typeof obj !== 'object' || !obj.keys) {
 				throw new Error(`Malformed Cloudflare Access public keys fetched from ${keysUrl}`)
 			}
+			const publicKeys = obj.keys
 			usingKeys = `fetched from ${keysUrl}`
-			publicKeysMemo = publicKeys.keys
+			publicKeysMemo = publicKeys
 			ctx.waitUntil(putPublicKeys(publicKeys))
-			return publicKeys.keys
+			return publicKeys
 		}
 
 		async function putPublicKeys(publicKeys) {
@@ -117,7 +118,7 @@ export default {
 					},
 					body: JSON.stringify({
 						name: 'CLOUDFLARE_ACCESS_PUBLIC_KEYS',
-						text: JSON.stringify(publicKeys.keys),
+						text: JSON.stringify(publicKeys),
 						type: 'secret_text'
 					})
 				}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,5 +2,33 @@ name = "access-jwt"
 main = "src/index.js"
 compatibility_date = "2024-11-12"
 
-[vars]
-ACCESS_TEAM_NAME = "jldec"
+[observability]
+enabled = true
+
+# secrets
+# CLOUDFLARE_ACCESS_PUBLIC_KEYS
+# CLOUDFLARE_ACCESS_TEAM_NAME
+# CLOUDFLARE_ACCOUNT_ID
+# CLOUDFLARE_API_TOKEN
+# CLOUDFLARE_WORKER_NAME
+#
+# https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/validating-json/
+# public keys fetched once a week with a cron worker from
+# https://${CLOUDFLARE_ACCESS_TEAM_NAME}.cloudflareaccess.com/cdn-cgi/access/certs
+# and cached in CLOUDFLARE_ACCESS_PUBLIC_KEYS secret on this worker using api
+#
+# curl
+# -X PUT
+# -d @.secret.json
+# -H "Content-Type: application/json"
+# -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}"
+# https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${CLOUDFLARE_WORKER_NAME}/secrets
+# CLOUDFLARE_API_TOKEN must have "Workers Scripts:Edit" permissions
+#
+# .secret.json has the shape:
+# {
+# 	"name": "CLOUDFLARE_ACCESS_PUBLIC_KEYS",
+# 	"text": "<keys-JSON>",
+# 	"type": "secret_text"
+# }
+# where keys-JSON contains the "keys:" property of the object returned from the certs endpoint


### PR DESCRIPTION
To avoid making a fetch request on the certs endpoint for every JWT validation, public keys are cached in a worker secret CLOUDFLARE_ACCESS_PUBLIC_KEYS. A query parameter of `f=1` will force this value to be refreshed. (TODO force a refresh with a weekly cron worker)

For Cloudflare API to set the secret, see 
https://discord.com/channels/595317990191398933/1293211664963076126/1293253667775840338 