### PR TITLE
Schedule handler for getPublicKeys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .dev.vars
 .secret.json
 put-secret.sh
+keys-*.json


### PR DESCRIPTION
This is an attempt to automate refetching (re-caching) the Access JWT public keys at a weekly rate so that automatic key rotation does not disrupt key validation.

Unfortunately I cannot test this, because the API to force key rotation appears to replace both keys at the same time, making it impossible to continue validating pre-existing JWTs while also validating new ones.

A support request has been raised in this discord thread
https://discord.com/channels/595317990191398933/1276620127676141598/1313129599538036786
